### PR TITLE
jmix-verify-bootrun: add Vaadin UI driving notes to Gate 3

### DIFF
--- a/content/skills/jmix-verify-bootrun/SKILL.md
+++ b/content/skills/jmix-verify-bootrun/SKILL.md
@@ -117,11 +117,36 @@ If you do have one, run the mechanical checks first, then:
    never becomes ready, tail the log, skip Gate 3, and shut the process down.
 3. With your browser/UI-automation tool, navigate to each view you created, click
    each button/action, fill each field, and confirm no error overlay or server
-   exception.
+   exception. A Jmix UI is a Vaadin web-component UI, so it does not respond to a
+   browser tool the way a plain HTML page does — see the next section.
 4. **Shut the background app down** when finished (`kill` the bootRun PID; if the
    port stays held, kill whatever holds it). Always leave the port free, and state
    in your report which database the walk ran against and what data it created
    there.
+
+### Driving a Jmix/Vaadin UI
+
+The page is built from `vaadin-*` custom elements, rendered by a client that keeps
+running after the HTTP response is done. Four consequences, each of which otherwise
+costs several failed tool calls:
+
+- **Wait for the client to render before you look.** The first screenshot or
+  snapshot right after navigation is routinely blank or half-built, because the
+  Vaadin client is still rendering. Retry until the content you expect is present;
+  never read "blank page" as a render failure on the first attempt.
+- **Refs go stale after every action.** Element handles from an accessibility
+  snapshot are invalidated by the next click, dialog, or grid reload. Retake the
+  snapshot immediately before each interaction instead of reusing refs captured
+  earlier in the walk.
+- **Role/name locators often miss `vaadin-*` components.** A locator such as
+  `getByRole('button', {name: 'OK'})` may not resolve against a `vaadin-button`.
+  Prefer a ref from the current snapshot; when a component exposes no usable role,
+  fall back to a DOM query on its tag name and visible text.
+- **A disabled action is usually a precondition, not a defect.** Jmix and add-on
+  actions enable on selection or on entity state — a grid action needs its row
+  selected, and an add-on action may need another step first (in the Quartz jobs
+  view, for example, Remove stays disabled until the selected job is paused).
+  Check the precondition before reporting the action as broken.
 
 ## Honest scope — Gate 3 is a render gate
 

--- a/content/skills/jmix-verify-bootrun/SKILL.md
+++ b/content/skills/jmix-verify-bootrun/SKILL.md
@@ -127,26 +127,17 @@ If you do have one, run the mechanical checks first, then:
 ### Driving a Jmix/Vaadin UI
 
 The page is built from `vaadin-*` custom elements, rendered by a client that keeps
-running after the HTTP response is done. Four consequences, each of which otherwise
-costs several failed tool calls:
+working after the HTTP response is done:
 
-- **Wait for the client to render before you look.** The first screenshot or
-  snapshot right after navigation is routinely blank or half-built, because the
-  Vaadin client is still rendering. Retry until the content you expect is present;
-  never read "blank page" as a render failure on the first attempt.
-- **Refs go stale after every action.** Element handles from an accessibility
-  snapshot are invalidated by the next click, dialog, or grid reload. Retake the
-  snapshot immediately before each interaction instead of reusing refs captured
-  earlier in the walk.
-- **Role/name locators often miss `vaadin-*` components.** A locator such as
-  `getByRole('button', {name: 'OK'})` may not resolve against a `vaadin-button`.
-  Prefer a ref from the current snapshot; when a component exposes no usable role,
-  fall back to a DOM query on its tag name and visible text.
-- **A disabled action is usually a precondition, not a defect.** Jmix and add-on
-  actions enable on selection or on entity state — a grid action needs its row
-  selected, and an add-on action may need another step first (in the Quartz jobs
-  view, for example, Remove stays disabled until the selected job is paused).
-  Check the precondition before reporting the action as broken.
+- **Wait for the client to render before you look.** The first snapshot or
+  screenshot after navigation is routinely blank; retry until the expected content
+  is there instead of reporting a render failure.
+- **Refs go stale after every action.** Retake the snapshot immediately before each
+  interaction rather than reusing refs captured earlier in the walk.
+- **Role/name locators often miss `vaadin-*` components.** Prefer a ref from the
+  current snapshot, falling back to a DOM query on tag name and visible text.
+- **A disabled action is usually a precondition, not a defect.** Jmix actions enable
+  on state — find and satisfy what this one waits for before reporting it broken.
 
 ## Honest scope — Gate 3 is a render gate
 


### PR DESCRIPTION
Fixes #29.

Drafted from a field report while the problem was fresh, by the agent that hit it. It is unreviewed: treat the wording as a starting point, not a proposal to merge as-is.

## Change

Adds a `### Driving a Jmix/Vaadin UI` subsection to Gate 3, plus one pointer sentence in step 3 of the walk. The four points are the ones that each cost failed tool calls during a real walk: wait for the Vaadin client to finish rendering before the first snapshot or screenshot; retake the snapshot before every interaction because refs go stale after each action; prefer refs from the current snapshot over role/name locators for `vaadin-*` components, with a DOM-query fallback when a component exposes no usable role; and treat a disabled action as a likely precondition (a required selection or entity state) rather than a defect.