### PR TITLE
jmix-verify-bootrun: branch Gate 3 on an already-running app the agent does not own

### DIFF
--- a/content/skills/jmix-verify-bootrun/SKILL.md
+++ b/content/skills/jmix-verify-bootrun/SKILL.md
@@ -104,6 +104,13 @@ landed.
 
 If you do have one, run the mechanical checks first, then:
 
+**If the application is already running** — the owner started it, possibly on a
+non-default port — take that base URL and port as given, do the walk against it,
+and do NOT run steps 1, 2 or 4: never start a second instance, and never shut down
+a process you do not own (the "leave the port free" in step 4 is only for the case
+where you started it yourself). Note in the report that the app was not started by
+the gate. The numbered steps below are for when you start and own the process.
+
 1. Start the app in the BACKGROUND so it does not block your turn, capturing its
    log — e.g. `nohup ./gradlew --no-daemon bootRun > /tmp/jmix_app.log 2>&1 &`,
    adding the datasource override above unless the walk is read-only.


### PR DESCRIPTION
Fixes #53.

Drafted from a field report while the problem was fresh, by the agent that hit it. It is unreviewed: treat the wording as a starting point, not a proposal to merge as-is.

## Change

Adds an 'application already running' branch before the numbered steps: take the given base URL and port, skip start/readiness-poll/shutdown, and never kill a process the agent does not own. Keeps the existing steps for the case where the agent starts the app itself.