### PR TITLE
jmix-create-test: note the fixed-name in-memory datasource is shared JVM-wide, not reset per context

### DIFF
--- a/content/skills/jmix-create-test/SKILL.md
+++ b/content/skills/jmix-create-test/SKILL.md
@@ -154,6 +154,7 @@ Before finishing, check:
 - The test command can run one class or method without running the full suite.
 - No `@Transactional` on the test class or methods — it rolls back the writes that `@AfterEach` cleanup and the twice-back-to-back run depend on.
 - Run the single class twice back-to-back — a second green run proves no leaked rows or cross-test data dependence that one pass hides.
+- An in-memory datasource with a FIXED name (`jdbc:hsqldb:mem:<fixed>`) is shared for the whole JVM/test run across every `@SpringBootTest` context that resolves to it — it is NOT reset per class or per method (HSQLDB's `mem:` catalog is registered by name for the JVM's lifetime). So `@AfterEach` cleanup is mandatory even for a test that only reads, or a later test in the same run sees its leftover rows; and a test that calls the same method twice to prove idempotency must not assume a fresh precondition between the two calls — set up explicitly the precondition the code under test actually checks.
 
 ## Forbidden
 


### PR DESCRIPTION
Fixes #55.

Drafted from a field report while the problem was fresh, by the agent that hit it. It is unreviewed: treat the wording as a starting point, not a proposal to merge as-is.

## Change

Adds a Cleanup-Audit bullet: a fixed-name `jdbc:hsqldb:mem:<fixed>` datasource is shared across every `@SpringBootTest` context for the whole JVM/test run, not reset per class or method — so `@AfterEach` cleanup is mandatory even for read-only tests, and a twice-called idempotency test must set its precondition explicitly.