### PR TITLE
jmix-create-test: require FK-safe deletion order in @AfterEach cleanup

### DIFF
--- a/content/skills/jmix-create-test/SKILL.md
+++ b/content/skills/jmix-create-test/SKILL.md
@@ -154,6 +154,7 @@ Before finishing, check:
 - The test command can run one class or method without running the full suite.
 - No `@Transactional` on the test class or methods — it rolls back the writes that `@AfterEach` cleanup and the twice-back-to-back run depend on.
 - Run the single class twice back-to-back — a second green run proves no leaked rows or cross-test data dependence that one pass hides.
+- `@AfterEach` deletions run in FK-safe order: child rows (holding a `@ManyToOne`/`@JoinColumn` to another cleaned-up entity) before the parents they reference. Re-check this whenever a new FK is added to an entity already covered by an existing cleanup block — a previously-safe order can silently become unsafe and throw a constraint violation in teardown, which JUnit reports against the test that triggered it rather than the cleanup, so it first reads as a test bug rather than an ordering one.
 
 ## Forbidden
 


### PR DESCRIPTION
Fixes #56.

Drafted from a field report while the problem was fresh, by the agent that hit it. It is unreviewed: treat the wording as a starting point, not a proposal to merge as-is.

## Change

Adds a Cleanup-Audit bullet: `@AfterEach` deletions must run in FK-safe order (child rows before the parents they reference), re-checked whenever a new FK is added to an already-covered entity, since a previously-safe order can silently become unsafe and fail in teardown.