### PR TITLE
jmix-ide-static-analysis: distrust all-errors results from files the IDE does not index

### DIFF
--- a/content/skills/jmix-ide-static-analysis/SKILL.md
+++ b/content/skills/jmix-ide-static-analysis/SKILL.md
@@ -45,6 +45,25 @@ flags the same Java errors a compile would). Rules when you use one:
   only generic/non-Jmix findings on a file you KNOW has a descriptor (a `*-view.xml`
   you just edited), treat the inspection as UNAVAILABLE for this run — do NOT call
   the file clean. Fall through to `compileJava` + the mechanical descriptor checks.
+- **Never trust an ALL-ERRORS result either — the IDE may not index the file.**
+  If the inspection reports "Cannot resolve symbol" for practically EVERY symbol,
+  including JDK types such as `String`, `List`, `Map`, that signature means "the
+  IDE is not indexing this file" — the result is garbage, not a broken file. The
+  bogus findings carry severity ERROR, so an errors-only filter does not remove
+  them; do NOT fix code from them. Disregard the whole result and fall back to
+  `compileJava` + the mechanical descriptor checks. For an XML-only edit, where
+  there are no JDK types to look for, the analogue is "message not found" on
+  `msg://` keys that grep DOES resolve in the module's `messages_*.properties`.
+  The most common cause is a git worktree nested under the project root (agent
+  tooling creates these routinely) while the IDE is opened on the main checkout:
+  the file IS inside the project directory, so the inspection accepts the path
+  and returns bogus findings instead of refusing loudly. Mechanical precondition
+  for any file type: `git rev-parse --show-toplevel` run in the edited file's
+  directory must equal `projectPath` — if it differs, the file lives in another
+  worktree and the inspection of that path is not authoritative. The same
+  signature also arises from a file outside any source root, a never-imported
+  Gradle project, or indexing lag right after files were written from outside
+  the IDE.
 - **A compile-only fallback leaves debt — record it.** When no inspection is
   connected, LIST the files that got only `compileJava` in your completion report,
   and re-inspect them the next time a session has the inspection available. A green


### PR DESCRIPTION
Fixes #62.

Drafted from a field report while the problem was fresh, by the agent that hit it. It is unreviewed: treat the wording as a starting point, not a proposal to merge as-is.

## Change

Adds a companion rule to the "Fallback decision rule" bullet: an all-errors inspection result whose unresolved symbols include JDK types (`String`, `List`, `Map`) means the IDE is not indexing the file — disregard it and fall back to `compileJava` plus the mechanical descriptor checks. Names the XML-only analogue ("message not found" for keys grep resolves in `messages_*.properties`), the git-worktree-nested-under-the-project-root cause, and a mechanical precondition (`git rev-parse --show-toplevel` must equal `projectPath`).
