### PR TITLE
jmix-create-entity, jmix-create-liquibase-changelog: branch for an inherited @MappedSuperclass key

### DIFF
--- a/content/skills/jmix-create-entity/SKILL.md
+++ b/content/skills/jmix-create-entity/SKILL.md
@@ -97,6 +97,15 @@ merely needs to be UNIQUE, which is a unique index on an ordinary column, not an
 id. Match the Liquibase column type to the Java type (`bigint` for `Long`, not
 `${uuid.type}`).
 
+**Inherited key from a framework `@MappedSuperclass`** — when the entity extends a
+base class the framework ships (the application-settings base, and other add-on
+base classes), the key is declared there already. Write NO `@Id`, no
+`@JmixGeneratedValue` and no `@Version` on the subclass. Read that superclass
+before writing the changelog: it decides the id column's name AND type — an `int`
+or `bigint` key is common there, so `${uuid.type}` is the wrong default — and it
+often contributes further columns (a version, a tenant column) that the table must
+still create even though no field in the subclass mentions them.
+
 ## Required references — BOTH annotations, or the field is not really required
 
 A required `@ManyToOne` needs the constraint in two places:

--- a/content/skills/jmix-create-liquibase-changelog/SKILL.md
+++ b/content/skills/jmix-create-liquibase-changelog/SKILL.md
@@ -45,6 +45,12 @@ An entity with an **assigned natural key** takes the id column type of its Java
 field — `bigint` for a `Long` id, not `${uuid.type}`. See `jmix-create-entity`
 (Id strategy).
 
+An entity extending a framework `@MappedSuperclass` inherits its key, and usually
+a version and a tenant column with it. No field in the subclass names them, but
+the table must still create them: read the superclass and take each inherited
+column's name and type from there — do not assume `${uuid.type}` for the primary
+key, these base classes are commonly keyed by an `int`.
+
 ## Entity Table Skeleton
 
 ```xml


### PR DESCRIPTION
Fixes #74.

Drafted from a field report while the problem was fresh, by the agent that hit it. It is unreviewed: treat the wording as a starting point, not a proposal to merge as-is.

## Change

`jmix-create-entity` — adds a third case to "Id strategy": an entity extending a framework `@MappedSuperclass` declares no `@Id`/`@JmixGeneratedValue`/`@Version`, and the superclass decides the id column's name and type plus any extra inherited columns.

`jmix-create-liquibase-changelog` — adds the mirroring note next to the assigned-natural-key paragraph in "Standard Types": the inherited columns still have to be created, read them off the superclass, do not assume `${uuid.type}`.