### PR TITLE
jmix-verify-api-symbol: a grep miss does not rule out an overload, and javap is not on PATH

### DIFF
--- a/content/skills/jmix-verify-api-symbol/SKILL.md
+++ b/content/skills/jmix-verify-api-symbol/SKILL.md
@@ -61,9 +61,7 @@ For anything NOT already in the project, verify it before you type it:
 
    Every cached jar on one classpath, so you need not know which artifact owns the
    class (`-p` also lists non-public members). `javap` ships inside the JDK and is
-   often NOT on `PATH` — call it as `$JAVA_HOME/bin/javap`, otherwise the bare
-   command fails with "command not found" and this check reads as unavailable,
-   which sends the agent back to guessing.
+   often NOT on `PATH` — call it as `$JAVA_HOME/bin/javap`.
 
    **Read the version the project resolves, not the newest one cached.** Whenever
    verification reads a framework artifact — a jar, an XSD, a sources archive —
@@ -79,14 +77,9 @@ For anything NOT already in the project, verify it before you type it:
    Find a real call site in the wider codebase or a reference app and copy its
    exact shape — useful when the symbol IS used somewhere, but blind when it is
    new to the project (use step 3 then).
-
-   A grep HIT proves the symbol exists; a grep MISS proves nothing. This bites on
-   OVERLOADS: when the class is already called in the project, this step looks like
-   it answered while it cannot tell whether the overload you need exists. The two
-   wrong guesses are not symmetrical — "the overload surely exists" fails at
-   `compileJava`, while "no call site, so no such method" compiles clean and leaves
-   a silent detour no gate catches. Whenever the question is *which overloads
-   exist*, use step 3.
+   A grep HIT proves the symbol exists; a grep MISS proves nothing. Use step 3 
+   whenever the question is "which overloads exist" — including when the class is 
+   already called elsewhere in the project.
 
 Never invent and ship. If nothing confirms a symbol, do not type it — pick one you
 CAN confirm, or omit the optional decoration (e.g. drop an icon attribute rather

--- a/content/skills/jmix-verify-api-symbol/SKILL.md
+++ b/content/skills/jmix-verify-api-symbol/SKILL.md
@@ -56,11 +56,14 @@ For anything NOT already in the project, verify it before you type it:
 
    ```bash
    CP=$(find ~/.gradle/caches -name '*.jar' ! -name '*sources*' | tr '\n' ':')
-   javap -p -cp "$CP" io.jmix.flowui.Dialogs
+   "$JAVA_HOME/bin/javap" -p -cp "$CP" io.jmix.flowui.Dialogs
    ```
 
    Every cached jar on one classpath, so you need not know which artifact owns the
-   class (`-p` also lists non-public members).
+   class (`-p` also lists non-public members). `javap` ships inside the JDK and is
+   often NOT on `PATH` — call it as `$JAVA_HOME/bin/javap`, otherwise the bare
+   command fails with "command not found" and this check reads as unavailable,
+   which sends the agent back to guessing.
 
    **Read the version the project resolves, not the newest one cached.** Whenever
    verification reads a framework artifact — a jar, an XSD, a sources archive —
@@ -76,6 +79,14 @@ For anything NOT already in the project, verify it before you type it:
    Find a real call site in the wider codebase or a reference app and copy its
    exact shape — useful when the symbol IS used somewhere, but blind when it is
    new to the project (use step 3 then).
+
+   A grep HIT proves the symbol exists; a grep MISS proves nothing. This bites on
+   OVERLOADS: when the class is already called in the project, this step looks like
+   it answered while it cannot tell whether the overload you need exists. The two
+   wrong guesses are not symmetrical — "the overload surely exists" fails at
+   `compileJava`, while "no call site, so no such method" compiles clean and leaves
+   a silent detour no gate catches. Whenever the question is *which overloads
+   exist*, use step 3.
 
 Never invent and ship. If nothing confirms a symbol, do not type it — pick one you
 CAN confirm, or omit the optional decoration (e.g. drop an icon attribute rather


### PR DESCRIPTION
Fixes #78.

Drafted from a field report while the problem was fresh, by the agent that hit it. It is unreviewed: treat the wording as a starting point, not a proposal to merge as-is.

## Change

Adds to step 4 that a grep hit proves existence while a grep miss proves nothing — which bites on overloads, where the class is already called in the project and the step looks like it answered. Also spells out the asymmetry of the two wrong guesses, and calls `javap` through `$JAVA_HOME/bin/javap` in step 3, since it ships inside the JDK and is often not on `PATH`.
