### PR TITLE
jmix-verify-api-symbol: add-on entity JPQL name comes from @Entity(name=...)

### DIFF
--- a/content/skills/jmix-verify-api-symbol/SKILL.md
+++ b/content/skills/jmix-verify-api-symbol/SKILL.md
@@ -107,6 +107,7 @@ Symbols commonly invented. NEVER type these — verify first:
 | `dialogs.createDetailView(this, entity, View.class)` | use `dialogWindows.detail(this, EntityClass.class).editEntity(entity).withViewClass(View.class)` |
 | `dataGrid.addItemChangeListener(...)`                | use `addSelectionListener(...)` or `asSingleSelect().addValueChangeListener(...)` |
 | `dataGrid.getSingleSelected()`                       | use `getSingleSelectedItem()`                                |
+| an add-on entity's JPQL name derived from its class name (`audit_EntityLogItem`) | actual: `audit_EntityLog` — an add-on entity's name comes from `@Entity(name = ...)` and need not match the class name; read it from the jar (step 3). Its neighbours `LoggedEntity` and `EntityLogAttr` DO match, so checking two of them and generalising gets the third one wrong |
 
 ## Cost vs benefit
 

--- a/content/skills/jmix-verify-api-symbol/SKILL.md
+++ b/content/skills/jmix-verify-api-symbol/SKILL.md
@@ -94,20 +94,20 @@ another package, another annotation member. Then use `javap` (step 3).
 
 Symbols commonly invented. NEVER type these — verify first:
 
-| You might type                                       | Reality                                                      |
-|------------------------------------------------------|--------------------------------------------------------------|
-| an invented `VaadinIcon` constant                    | does not exist; the icon enum is small and irregular — pick from existing constants or omit |
-| `JmixButton.ClickEvent`                              | use `com.vaadin.flow.component.ClickEvent<JmixButton>`       |
-| `DataGrid.ReadEvent`, `DataGrid.SelectionEvent`      | use `com.vaadin.flow.data.selection.SelectionEvent<DataGrid<E>, E>` |
-| `Target.DATA_GRID`                                   | not a Jmix `@Subscribe` target — use `Target.COMPONENT` with explicit id |
-| `io.jmix.flowui.dialogs.Dialogs`                     | actual: `io.jmix.flowui.Dialogs`                             |
-| `io.jmix.core.entity.EntityStates`                   | actual: `io.jmix.core.EntityStates`                          |
-| `io.jmix.flowui.component.datagrid.DataGrid`         | actual: `io.jmix.flowui.component.grid.DataGrid`             |
+| You might type                                       | Reality                                                                                                                                                     |
+|------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| an invented `VaadinIcon` constant                    | does not exist; the icon enum is small and irregular — pick from existing constants or omit                                                                 |
+| `JmixButton.ClickEvent`                              | use `com.vaadin.flow.component.ClickEvent<JmixButton>`                                                                                                      |
+| `DataGrid.ReadEvent`, `DataGrid.SelectionEvent`      | use `com.vaadin.flow.data.selection.SelectionEvent<DataGrid<E>, E>`                                                                                         |
+| `Target.DATA_GRID`                                   | not a Jmix `@Subscribe` target — use `Target.COMPONENT` with explicit id                                                                                    |
+| `io.jmix.flowui.dialogs.Dialogs`                     | actual: `io.jmix.flowui.Dialogs`                                                                                                                            |
+| `io.jmix.core.entity.EntityStates`                   | actual: `io.jmix.core.EntityStates`                                                                                                                         |
+| `io.jmix.flowui.component.datagrid.DataGrid`         | actual: `io.jmix.flowui.component.grid.DataGrid`                                                                                                            |
 | `io.jmix.flowui.component.markdown.Markdown`         | actual: `com.vaadin.flow.component.markdown.Markdown` — the `<markdown>` component is Vaadin's; `io.jmix.flowui` has a DIFFERENT `markdowneditor` component |
-| `dialogs.createDetailView(this, entity, View.class)` | use `dialogWindows.detail(this, EntityClass.class).editEntity(entity).withViewClass(View.class)` |
-| `dataGrid.addItemChangeListener(...)`                | use `addSelectionListener(...)` or `asSingleSelect().addValueChangeListener(...)` |
-| `dataGrid.getSingleSelected()`                       | use `getSingleSelectedItem()`                                |
-| an add-on entity's JPQL name derived from its class name (`audit_EntityLogItem`) | actual: `audit_EntityLog` — an add-on entity's name comes from `@Entity(name = ...)` and need not match the class name; read it from the jar (step 3). Its neighbours `LoggedEntity` and `EntityLogAttr` DO match, so checking two of them and generalising gets the third one wrong |
+| `dialogs.createDetailView(this, entity, View.class)` | use `dialogWindows.detail(this, EntityClass.class).editEntity(entity).withViewClass(View.class)`                                                            |
+| `dataGrid.addItemChangeListener(...)`                | use `addSelectionListener(...)` or `asSingleSelect().addValueChangeListener(...)`                                                                           |
+| `dataGrid.getSingleSelected()`                       | use `getSingleSelectedItem()`                                                                                                                               |
+| an add-on entity's JPQL name derived from its class name (`audit_EntityLogItem`) | actual: `audit_EntityLog` — an add-on entity's name comes from `@Entity(name = ...)` and need not match the class name; read it from the jar (step 3)       |
 
 ## Cost vs benefit
 


### PR DESCRIPTION
Fixes #79.

Drafted from a field report while the problem was fresh, by the agent that hit it. It is unreviewed: treat the wording as a starting point, not a proposal to merge as-is.

## Change

One row in the trap catalogue: an add-on entity's JPQL name is declared in `@Entity(name = ...)` and need not match the class name, with the worked `EntityLogItem` -> `audit_EntityLog` example and the note that its two neighbours DO match, so generalising from a sample of two gets the third wrong.
