### PR TITLE
jmix-create-list-view: column widths in rem, and saved settings outrank the descriptor

### DIFF
--- a/content/skills/jmix-create-list-view/SKILL.md
+++ b/content/skills/jmix-create-list-view/SKILL.md
@@ -226,6 +226,39 @@ The same holds for every overridden view lifecycle method (`beforeEnter`,
 `afterNavigation`): do your work, then call `super`, on every code path. An
 early `return` before `super` is the defect.
 
+## Column widths — `rem` or px, never `em`
+
+```xml
+<column property="number" width="9rem"/>   <!-- RIGHT -->
+<column property="number" width="9em"/>    <!-- WRONG: header and body drift apart -->
+```
+
+`em` resolves against the font size of the element it is applied to, and the Lumo
+theme deliberately sets the grid header smaller than the body
+(`--lumo-font-size-s` 14px against `--lumo-font-size-m` 16px). The same `9em` becomes
+126px in the header and 144px in the body — 8/7 per column, accumulating rightwards
+until the last column is off by a wide margin. Vaadin documents this on Grid:
+"Using the em length unit is discouraged as it might lead to misalignment issues if
+the header, body, and footer cells have different font sizes. Instead, use rem."
+
+The defect hides itself on narrow tables — the first columns line up — so a small
+grid gives no warning that the rule was broken.
+
+### Saved column settings outrank the descriptor
+
+`<settings auto="true"/>` persists width, order and visibility per user. Those saved
+values are applied OVER the descriptor on open, they carry no version marker, and
+editing the descriptor does not invalidate them. So after changing a width, the
+change is visible only to users who never opened that list.
+
+The symptom is indistinguishable from "the deployment did not arrive": new value in
+the source, old value on screen. And it disables verification — **until the saved
+settings are cleared, checking a width change in the browser proves nothing**, which
+makes a correct change look broken and invites a second "fix" of working code.
+
+After changing width, order or the set of columns, clear the stored settings for that
+view (`FLOWUI_USER_SETTINGS`) before verifying.
+
 ## Forbidden
 
 - Declaring actions without visible buttons or another reachable UI trigger.
@@ -239,3 +272,5 @@ early `return` before `super` is the defect.
 - Adding menu policy for dialog-only detail views.
 - A load delegate returning `LoadContext` instead of `List<E>` (the query never runs; the grid is empty at open).
 - An overridden `beforeEnter` that does not call `super.beforeEnter(event)` on every path (the auto-load never fires; the grid is empty).
+- `<column width="…em">` — header and body resolve `em` against different font sizes and drift apart.
+- Verifying a column-width change in the browser without clearing saved user settings first — the check returns a false negative.

--- a/content/skills/jmix-create-list-view/SKILL.md
+++ b/content/skills/jmix-create-list-view/SKILL.md
@@ -244,20 +244,25 @@ the header, body, and footer cells have different font sizes. Instead, use rem."
 The defect hides itself on narrow tables — the first columns line up — so a small
 grid gives no warning that the rule was broken.
 
-### Saved column settings outrank the descriptor
+## Saved user settings outrank the descriptor
 
-`<settings auto="true"/>` persists width, order and visibility per user. Those saved
-values are applied OVER the descriptor on open, they carry no version marker, and
-editing the descriptor does not invalidate them. So after changing a width, the
-change is visible only to users who never opened that list.
+Applies when the view declares a `<settings>` facet (e.g. `<settings auto="true"/>`).
+This skill's skeleton does not add one, but existing views often have it.
+
+The facet persists column width, order and visibility per user. Saved values are
+applied OVER the descriptor on open, they carry no version marker, and editing the
+descriptor does not invalidate them. The user does not have to touch anything:
+opening the view once is enough — a full snapshot of all columns is saved on leave.
+So after a descriptor change, the change is visible only to users who never opened
+that view.
 
 The symptom is indistinguishable from "the deployment did not arrive": new value in
 the source, old value on screen. And it disables verification — **until the saved
-settings are cleared, checking a width change in the browser proves nothing**, which
+settings are cleared, checking such a change in the browser proves nothing**, which
 makes a correct change look broken and invites a second "fix" of working code.
 
-After changing width, order or the set of columns, clear the stored settings for that
-view (`FLOWUI_USER_SETTINGS`) before verifying.
+After changing column width, order or visibility on a view with a settings facet,
+clear the stored settings for that view (`FLOWUI_USER_SETTINGS`) before verifying.
 
 ## Forbidden
 
@@ -273,4 +278,4 @@ view (`FLOWUI_USER_SETTINGS`) before verifying.
 - A load delegate returning `LoadContext` instead of `List<E>` (the query never runs; the grid is empty at open).
 - An overridden `beforeEnter` that does not call `super.beforeEnter(event)` on every path (the auto-load never fires; the grid is empty).
 - `<column width="…em">` — header and body resolve `em` against different font sizes and drift apart.
-- Verifying a column-width change in the browser without clearing saved user settings first — the check returns a false negative.
+- On a view with a `<settings>` facet: verifying a change to column width, order or visibility in the browser without clearing saved user settings first — the check returns a false negative.


### PR DESCRIPTION
Fixes #80.

Drafted from a field report while the problem was fresh, by the agent that hit it. It is unreviewed: treat the wording as a starting point, not a proposal to merge as-is.

## Change

Adds a "Column widths" section: why `em` makes the Lumo header (14px) and body (16px) resolve the same value differently and drift 8/7 per column, and that the defect hides on narrow tables. Plus a subsection on saved user settings overriding the descriptor permanently — including the part that matters most, that until they are cleared a browser check of a width change returns a false negative. Two Forbidden entries.
