### PR TITLE
jmix-create-entity/test: a new entity needs a full clean test first

### DIFF
--- a/content/skills/jmix-create-entity/SKILL.md
+++ b/content/skills/jmix-create-entity/SKILL.md
@@ -268,6 +268,30 @@ and the suite passes — so writing the one new entity with hand-written accesso
 makes it the odd one out for a breakage that does not occur. In a project with
 hand-written accessors, write them by hand.
 
+## A NEW entity needs a full `clean test` first
+
+After adding a new `@JmixEntity`, make the FIRST run a full `./gradlew clean test`.
+A targeted `test --tests '*Something*'` can execute against a stale build result, and
+then every test in the class fails at context load with a message that names the new
+entity:
+
+```
+IllegalArgumentException: MetaClass not found for class com.company.app.entity.Department
+    at io.jmix.security.impl.role.builder.extractor.PolicyExtractorUtils.getEntityNameByEntityClass
+```
+
+The same `clean test`, with no edit at all, is green.
+
+This matters because the two documented causes of `MetaClass not found` — a missing
+`@JmixEntity`, a package outside the scan root — are both FALSE here, so following
+them sends you to "repair" code that is already correct. The frame it surfaces from
+(role building) adds to the illusion by making it look like a broken security policy.
+The same symptom has also appeared without any new entity, after a source file was
+rewritten wholesale, naming an entity that had not been touched.
+
+Third cause for that list: **a stale build. Confirmed by one `clean test`; requires no
+code change.**
+
 ## Composition Checklist
 
 For parent-child aggregates:

--- a/content/skills/jmix-create-test/SKILL.md
+++ b/content/skills/jmix-create-test/SKILL.md
@@ -18,7 +18,10 @@ Use this skill when adding or changing tests for Jmix application behavior.
 7. Set authentication with the project's `AuthenticatedAsAdmin` extension or `SystemAuthenticator`.
 8. Clean up created persistent data in `@AfterEach`.
 9. Mock external systems at the boundary; prefer `@MockitoBean` on Spring Boot 3.4+ projects and follow the project's existing compiled pattern otherwise.
-10. Run the smallest relevant Gradle test command.
+10. Run the smallest relevant Gradle test command — but after adding a NEW entity make
+    the first run a full `clean test`: a targeted `--tests` run may execute against a
+    stale metamodel and fail with `MetaClass not found` on correct code (see
+    `jmix-create-entity`).
 
 Before typing any Jmix/Vaadin symbol you didn't copy from this project's `src` — a class, enum constant, action id, component, or event inner-class — confirm it. A guessed symbol survives typing and then breaks `compileJava`. Use the Context7 MCP (`/jmix-framework/jmix-context7`) when available, otherwise the official docs plus a working example already in this repo — see `jmix-verify-api-symbol`.
 


### PR DESCRIPTION
Fixes #81.

Drafted from a field report while the problem was fresh, by the agent that hit it. It is unreviewed: treat the wording as a starting point, not a proposal to merge as-is.

## Change

Adds a section to `jmix-create-entity` and one clause to step 10 of `jmix-create-test`: after adding a new entity the first run must be a full `clean test`, because a targeted `--tests` run can execute against a stale build and fail with `MetaClass not found` on correct code. States the third cause explicitly — a stale build, cured by `clean`, requiring no code change — since the two documented causes are both false in that case and send you to "repair" working code.
