### PR TITLE
jmix-create-detail-view: asking for confirmation before saving (BeforeSaveEvent)

### DIFF
--- a/content/skills/jmix-create-detail-view/SKILL.md
+++ b/content/skills/jmix-create-detail-view/SKILL.md
@@ -272,6 +272,37 @@ grid is empty (see `jmix-configure-fetch-plan`).
 For a read-only grid, declare no `list_create` / `list_edit` / `list_remove`
 actions on it.
 
+## Asking for confirmation before saving
+
+`ValidationEvent` can only REJECT a save; it cannot ask a question and continue.
+The only hook that suspends a save and resumes it afterwards is
+`StandardDetailView.BeforeSaveEvent` with `preventSave()` / `resume()`:
+
+```java
+@Autowired
+private Dialogs dialogs;
+
+@Subscribe
+public void onBeforeSave(final BeforeSaveEvent event) {
+    if (!reissuesRelatedCodes()) {
+        return;
+    }
+    event.preventSave();
+    dialogs.createOptionDialog()
+            .withHeader(messageBundle.getMessage("confirmDialog.header"))
+            .withText(messageBundle.getMessage("confirmDialog.text"))
+            .withActions(
+                    new DialogAction(DialogAction.Type.YES)
+                            .withHandler(e -> event.resume()),
+                    new DialogAction(DialogAction.Type.NO))
+            .open();
+}
+```
+
+Note `Dialogs.createOptionDialog()` takes NO view argument, unlike
+`createInputDialog(View)`. Without `preventSave()` the save runs on regardless of what
+a dialog is showing, so a home-made confirmation dialog does not hold anything back.
+
 ## Cross-field validation
 
 For cross-field/manual validation, add a `@Subscribe` handler on `ValidationEvent` and report failures via `event.getErrors().add("...")`; for programmatic checks (e.g. before a custom save) use the `ViewValidation` bean (`validateUiComponents`, `showValidationErrors`).


### PR DESCRIPTION
Fixes #84.

Drafted from a field report while the problem was fresh, by the agent that hit it. It is unreviewed: treat the wording as a starting point, not a proposal to merge as-is.

## Change

Adds an "Asking for confirmation before saving" section. `ValidationEvent` can only reject, so it cannot ask; `BeforeSaveEvent.preventSave()` / `resume()` is the only hook that suspends and resumes a save. Includes a worked example with `Dialogs.createOptionDialog()`, and notes it takes no view argument unlike `createInputDialog(View)`.
