### PR TITLE
jmix-add-entity-event-listener: EntityChangedEvent arrives after the flush

### DIFF
--- a/content/skills/jmix-add-entity-event-listener/SKILL.md
+++ b/content/skills/jmix-add-entity-event-listener/SKILL.md
@@ -109,6 +109,20 @@ Use normal Spring `@EventListener` for logic that must affect the current save/r
 
 `@TransactionalEventListener` is for after-transaction reactions such as notifications or integration events. Do not use it when failure must roll back or reject the current persistence operation.
 
+`EntityChangedEvent` (before commit) is delivered AFTER the SQL flush. If the write
+being validated can itself violate a database constraint, the constraint error is
+raised first and the listener never runs. The invariant still holds — the save is
+rejected either way — but two things follow:
+
+- the user gets a raw database error instead of the listener's explanation, so
+  validation of this kind must not rely on its own message reaching anyone; catch
+  `DataIntegrityViolationException` on the calling side and translate it, or accept
+  both outcomes;
+- tests for such a listener must use data where the constraint provably cannot fire.
+  Otherwise the test asserts the listener's message and gets whichever arrives first,
+  turning green or red depending on what neighbouring tests have already consumed —
+  green on a targeted run, red on a full `clean test`.
+
 Use `EntityChangedEvent.Type.DELETED` to detect deletes. Deleted entity instances cannot be loaded by `event.getEntityId()` because they have already been removed, so delete-side logic must use the old values and old reference ids available from `event.getChanges()`.
 
 For `Type.DELETED`, `event.getChanges()` snapshots every non-read-only property of the entity with its last-known pre-delete value — unlike `Type.UPDATED`, where only actually-mutated attributes appear. So `getOldValue(name)` works for scalar (non-reference) attributes too, and references come back as ids:

--- a/content/skills/jmix-add-entity-event-listener/SKILL.md
+++ b/content/skills/jmix-add-entity-event-listener/SKILL.md
@@ -26,7 +26,9 @@ Use this skill when business logic must react to entity save, change, delete, or
 12. Search the changed code for `@TransactionalEventListener`; if the listener performs validation, rejects updates/deletes, sets required defaults, or performs required synchronous side effects, replace it with `@EventListener` plus `EntitySavingEvent`/`EntityChangedEvent` or another before-commit path.
 13. Add tests or at least compile/startup validation for the event listener.
 
-## EntityChangedEvent Listener Template
+## EntityChangedEvent
+
+### Listener Template
 
 ```java
 import io.jmix.core.DataManager;
@@ -76,7 +78,7 @@ public class LedgerEntryEventListener {
 }
 ```
 
-## Fetch Plan Safety
+### Fetch Plan Safety
 
 For non-deleted events, the loaded entity should contain every property the listener reads. The safest default is loading by event id with the normal plan:
 
@@ -98,7 +100,7 @@ ledgerService.apply(entry.getAccount().getId(), entry.getAmount(), entry.getType
 
 After writing the listener, scan the method: every `entry.getX()` used after loading must be available in the fetch plan.
 
-## Event Timing
+### Event Timing
 
 Use normal Spring `@EventListener` for logic that must affect the current save/remove operation:
 
@@ -111,17 +113,7 @@ Use normal Spring `@EventListener` for logic that must affect the current save/r
 
 `EntityChangedEvent` (before commit) is delivered AFTER the SQL flush. If the write
 being validated can itself violate a database constraint, the constraint error is
-raised first and the listener never runs. The invariant still holds — the save is
-rejected either way — but two things follow:
-
-- the user gets a raw database error instead of the listener's explanation, so
-  validation of this kind must not rely on its own message reaching anyone; catch
-  `DataIntegrityViolationException` on the calling side and translate it, or accept
-  both outcomes;
-- tests for such a listener must use data where the constraint provably cannot fire.
-  Otherwise the test asserts the listener's message and gets whichever arrives first,
-  turning green or red depending on what neighbouring tests have already consumed —
-  green on a targeted run, red on a full `clean test`.
+raised first and the listener never runs.
 
 Use `EntityChangedEvent.Type.DELETED` to detect deletes. Deleted entity instances cannot be loaded by `event.getEntityId()` because they have already been removed, so delete-side logic must use the old values and old reference ids available from `event.getChanges()`.
 


### PR DESCRIPTION
Fixes #87.

Drafted from a field report while the problem was fresh, by the agent that hit it. It is unreviewed: treat the wording as a starting point, not a proposal to merge as-is.

## Change

Adds to Event Timing that `EntityChangedEvent` (before commit) is delivered after the SQL flush, so a constraint violation on the same write pre-empts the listener. Two consequences: such validation cannot rely on its own message reaching the user, and its tests must use data where the constraint cannot fire — otherwise they turn green or red depending on what neighbouring tests consumed.
