### PR TITLE
jmix-add-i18n-keys: scope the translated-values audit to the bundle

### DIFF
--- a/content/skills/jmix-add-i18n-keys/SKILL.md
+++ b/content/skills/jmix-add-i18n-keys/SKILL.md
@@ -133,10 +133,9 @@ Do not rely on similar casing such as `CreateOrderButton.text` or `createorderBu
 
 ### 2. Verify translated values
 
-The scope is the BUNDLE, not whether `en` is declared. Every locale bundle other
-than the one whose language the keys are authored in must be reviewed for leftover
-template values — including in an `en,<other>` application, where the second bundle
-is generated as an English template and every key in it resolves.
+Every locale bundle other than the one whose language the keys are authored in must be reviewed for leftover template
+values — including in an `en,<other>` application, where the second bundle is generated as an English template and every
+key in it resolves.
 
 Read each such `messages_<locale>.properties` file complete, not only the lines
 changed during the task. Project templates can contain English values under keys

--- a/content/skills/jmix-add-i18n-keys/SKILL.md
+++ b/content/skills/jmix-add-i18n-keys/SKILL.md
@@ -133,11 +133,15 @@ Do not rely on similar casing such as `CreateOrderButton.text` or `createorderBu
 
 ### 2. Verify translated values
 
-When `jmix.core.available-locales` does not include `en`, read every complete
-`messages_<locale>.properties` file, not only the lines changed during the task.
-Project templates can contain English values under keys that resolve correctly,
-so the reference audit does not detect them. Check seed keys for the login view,
-main view, menu, and user entity as well as newly added keys.
+The scope is the BUNDLE, not whether `en` is declared. Every locale bundle other
+than the one whose language the keys are authored in must be reviewed for leftover
+template values — including in an `en,<other>` application, where the second bundle
+is generated as an English template and every key in it resolves.
+
+Read each such `messages_<locale>.properties` file complete, not only the lines
+changed during the task. Project templates can contain English values under keys
+that resolve correctly, so the reference audit does not detect them. Check seed keys
+for the login view, main view, menu, and user entity as well as newly added keys.
 
 For a locale that normally uses non-Latin text, use this search to find likely
 English values left from the template:
@@ -153,6 +157,12 @@ be valid. Values such as `MainView.title=App`, `User=User`, or
 `loginForm.username=Username` usually require translation in a non-English-only
 application.
 
+When the task adds keys to a bundle that is still an untouched template, pick one of
+two outcomes and say which — translating the whole bundle, or translating only the
+new keys and recording the rest as a known gap. Both are defensible. Translating the
+new keys and silently leaving the seed keys is not: it produces a half-translated UI
+that reads as an oversight.
+
 ## Forbidden
 
 - Hardcoded user-visible text in XML or Java controllers.
@@ -163,5 +173,5 @@ application.
 - `${0}` placeholders in `formatMessage`; use Java formatter placeholders such as `%s`.
 - Copies of framework or add-on message bundles created before checking for an
   official `jmix-translations-<lang>` artifact.
-- English template values left in a non-English-only application bundle without
-  explicit review.
+- English template values left without explicit review in any locale bundle other
+  than the one the keys are authored in — an `en,<other>` application included.


### PR DESCRIPTION
Fixes #107.

Drafted from a field report while the problem was fresh, by the agent that hit it. It is unreviewed: treat the wording as a starting point, not a proposal to merge as-is.

## Change

Rescopes audit step 2 from "when `jmix.core.available-locales` does not include `en`" to the bundle itself — every locale bundle other than the one the keys are authored in — so it no longer contradicts the Forbidden bullet, which is reworded to match. Adds the missing instruction for a bundle that is still an untouched template: translate all of it, or translate the new keys and record the rest as a known gap, but say which.

This is a follow-up to #44, whose fix introduced the `en` gate.