### PR TITLE
jmix-add-entity-event-listener: decide listener timing by direction of failure

### DIFF
--- a/content/skills/jmix-add-entity-event-listener/SKILL.md
+++ b/content/skills/jmix-add-entity-event-listener/SKILL.md
@@ -23,7 +23,7 @@ Use this skill when business logic must react to entity save, change, delete, or
 9. Use a before-commit `@EventListener` path for validation that must reject the current save/remove operation.
 10. Put multi-entity changes in a transactional service method when atomicity matters.
 11. Reject unsupported updates/deletes inside the event path before treating work as complete.
-12. Search the changed code for `@TransactionalEventListener`; if the listener performs validation, rejects updates/deletes, sets required defaults, or performs required synchronous side effects, replace it with `@EventListener` plus `EntitySavingEvent`/`EntityChangedEvent` or another before-commit path.
+12. Search the changed code for `@TransactionalEventListener`; if the listener performs validation, rejects updates/deletes, or sets required defaults, replace it with `@EventListener` plus `EntitySavingEvent`/`EntityChangedEvent` or another before-commit path. Decide by the direction of failure, not by whether the side effect is required — see "Event Timing".
 13. Add tests or at least compile/startup validation for the event listener.
 
 ## EntityChangedEvent
@@ -111,6 +111,25 @@ Use normal Spring `@EventListener` for logic that must affect the current save/r
 
 `@TransactionalEventListener` is for after-transaction reactions such as notifications or integration events. Do not use it when failure must roll back or reject the current persistence operation.
 
+**The criterion is the direction of failure, not whether the side effect is required.**
+A handler that must be able to REJECT the operation belongs before commit. A handler
+that mutates a resource the database transaction cannot roll back — file storage, an
+external API, an outbound notification — belongs AFTER commit, however required it is.
+
+The mistake this prevents: deleting an uploaded file from a before-commit handler
+because the deletion is "a required synchronous side effect". `EntityChangedEvent` is
+published in `beforeCommit`, so if anything later aborts the transaction the row is
+still there and its file is gone — the exact inverse of the leak the handler exists to
+prevent.
+
+Nothing is lost by waiting. `AttributeChanges` is an immutable snapshot taken before
+the events are published — a `final Set<Change>`, each holding a `final Object oldValue`,
+with no reference to the entity or the persistence context — so `event.getChanges()`
+reads identically from an `AFTER_COMMIT` handler.
+
+The corollary is worth a test: an `AFTER_COMMIT` handler never runs when the transaction
+rolls back, so a test asserting it fired is the only proof it is wired at all.
+
 `EntityChangedEvent` (before commit) is delivered AFTER the SQL flush. If the write
 being validated can itself violate a database constraint, the constraint error is
 raised first and the listener never runs.
@@ -174,6 +193,7 @@ what is in the database and overwrites values set in memory but not yet saved.
 - Assuming `EntityChangedEvent` directly contains the full entity instance.
 - Assuming `EntityLoadingEvent` is a replacement for fetching references or running cross-entity queries.
 - Reading an entity property that is omitted from a custom fetch plan.
-- `@TransactionalEventListener` for validation, required synchronous side effects, or immutable-record enforcement.
+- `@TransactionalEventListener` for validation, or for immutable-record enforcement — anything that must be able to reject the operation.
+- A before-commit handler for a side effect the transaction cannot undo (file storage, external APIs, notifications).
 - Putting UI code in entity listeners.
 - Side effects without an explicit service method when several entities must stay consistent.

--- a/content/skills/jmix-add-entity-event-listener/SKILL.md
+++ b/content/skills/jmix-add-entity-event-listener/SKILL.md
@@ -23,7 +23,7 @@ Use this skill when business logic must react to entity save, change, delete, or
 9. Use a before-commit `@EventListener` path for validation that must reject the current save/remove operation.
 10. Put multi-entity changes in a transactional service method when atomicity matters.
 11. Reject unsupported updates/deletes inside the event path before treating work as complete.
-12. Search the changed code for `@TransactionalEventListener`; if the listener performs validation, rejects updates/deletes, or sets required defaults, replace it with `@EventListener` plus `EntitySavingEvent`/`EntityChangedEvent` or another before-commit path. Decide by the direction of failure, not by whether the side effect is required — see "Event Timing".
+12. Search the changed code for `@TransactionalEventListener`; if the listener performs validation, rejects updates/deletes, or sets required defaults, replace it with `@EventListener` plus `EntitySavingEvent`/`EntityChangedEvent` or another before-commit path. Decide by the direction of failure — see "Event Timing".
 13. Add tests or at least compile/startup validation for the event listener.
 
 ## EntityChangedEvent
@@ -111,7 +111,7 @@ Use normal Spring `@EventListener` for logic that must affect the current save/r
 
 `@TransactionalEventListener` is for after-transaction reactions such as notifications or integration events. Do not use it when failure must roll back or reject the current persistence operation.
 
-**The criterion is the direction of failure, not whether the side effect is required.**
+**The criterion is the direction of failure.**
 A handler that must be able to REJECT the operation belongs before commit. A handler
 that mutates a resource the database transaction cannot roll back — file storage, an
 external API, an outbound notification — belongs AFTER commit, however required it is.
@@ -121,14 +121,6 @@ because the deletion is "a required synchronous side effect". `EntityChangedEven
 published in `beforeCommit`, so if anything later aborts the transaction the row is
 still there and its file is gone — the exact inverse of the leak the handler exists to
 prevent.
-
-Nothing is lost by waiting. `AttributeChanges` is an immutable snapshot taken before
-the events are published — a `final Set<Change>`, each holding a `final Object oldValue`,
-with no reference to the entity or the persistence context — so `event.getChanges()`
-reads identically from an `AFTER_COMMIT` handler.
-
-The corollary is worth a test: an `AFTER_COMMIT` handler never runs when the transaction
-rolls back, so a test asserting it fired is the only proof it is wired at all.
 
 `EntityChangedEvent` (before commit) is delivered AFTER the SQL flush. If the write
 being validated can itself violate a database constraint, the constraint error is


### PR DESCRIPTION
Fixes #108.

Drafted from a field report while the problem was fresh, by the agent that hit it. It is unreviewed: treat the wording as a starting point, not a proposal to merge as-is.

## Change

Replaces "required synchronous side effects" — in step 12 and in Forbidden — with the criterion that actually decides the annotation: before commit for anything that must be able to REJECT the operation, after commit for anything the transaction cannot roll back, however required. Adds the worked case (deleting a file from a before-commit handler leaves the row alive with its file gone), the fact that `AttributeChanges` is a pre-publication snapshot and so reads identically from `AFTER_COMMIT`, and the testing corollary.

The old wording sent two review rounds in opposite directions on the same handler, which is what makes this a wording problem rather than a missing note.

Branches from `v3` alongside the PRs for #105 and #106, which touch the same file; #106 adds text in the same neighbourhood, so one of the two will need a rebase.