### PR TITLE
jmix-create-entity, jmix-create-liquibase-changelog: check column names against each dialect's reserved words

### DIFF
--- a/content/skills/jmix-create-entity/SKILL.md
+++ b/content/skills/jmix-create-entity/SKILL.md
@@ -17,11 +17,36 @@ Use this skill when adding or changing a database-backed Jmix entity.
 4. Add `@Version`.
 5. Add `@InstanceName` on a stable human-readable field or method.
 6. Define columns with exact `nullable`, `length`, `precision`, and `scale` constraints from requirements.
+   **Check every column name against the reserved words of every targeted dialect** — see
+   "Column names — a reserved word fails on one dialect and passes on another" below.
 7. Use `FetchType.LAZY` for relationships.
 8. Create the Liquibase changelog using `jmix-create-liquibase-changelog`.
 9. Add entity and attribute message keys using `jmix-add-i18n-keys`.
 10. Add or update views and security roles if the entity is user-facing.
 11. Before finishing, compare every required constraint against the source requirements and the Liquibase changelog.
+
+## Column names — a reserved word fails on one dialect and passes on another
+
+A column name derived from the field name may be an SQL **reserved word**, and
+the dialects a project targets do not agree about which words those are. The
+check is per dialect, not per SQL standard: a green suite against the test store
+proves nothing about the production store.
+
+- **PostgreSQL:** `select catcode from pg_get_keywords() where word = '<lower-case name>'`
+  — `reserved` cannot be used as an identifier at all. `END` is reserved;
+  `START`, `LANGUAGE`, `TEXT`, `TYPE` and `NAME` are unreserved and fine.
+- **HSQLDB** (the usual test store): default settings accept SQL-standard
+  keywords as identifiers, so it will NOT warn you — `START`, `END` and
+  `LANGUAGE` all pass there in DDL, INSERT, SELECT and UPDATE.
+
+Rename the field or give it an explicit prefixed `@Column(name = "...")`. Common
+offenders an entity field naturally produces: `end`, `order`, `user`, `group`,
+`desc`, `references`.
+
+This is the expensive failure mode. Liquibase emits the `createTable` unquoted
+and EclipseLink emits `t.END` unquoted, so the defect surfaces only when the
+changelog is first applied to the production dialect — after compile, static
+analysis and a full green `clean test` have all passed.
 
 ## Entity Template
 

--- a/content/skills/jmix-create-entity/SKILL.md
+++ b/content/skills/jmix-create-entity/SKILL.md
@@ -17,36 +17,12 @@ Use this skill when adding or changing a database-backed Jmix entity.
 4. Add `@Version`.
 5. Add `@InstanceName` on a stable human-readable field or method.
 6. Define columns with exact `nullable`, `length`, `precision`, and `scale` constraints from requirements.
-   **Check every column name against the reserved words of every targeted dialect** — see
-   "Column names — a reserved word fails on one dialect and passes on another" below.
+   **Check every column name against the reserved words of every targeted dialect** — see "Column names" below.
 7. Use `FetchType.LAZY` for relationships.
 8. Create the Liquibase changelog using `jmix-create-liquibase-changelog`.
 9. Add entity and attribute message keys using `jmix-add-i18n-keys`.
 10. Add or update views and security roles if the entity is user-facing.
 11. Before finishing, compare every required constraint against the source requirements and the Liquibase changelog.
-
-## Column names — a reserved word fails on one dialect and passes on another
-
-A column name derived from the field name may be an SQL **reserved word**, and
-the dialects a project targets do not agree about which words those are. The
-check is per dialect, not per SQL standard: a green suite against the test store
-proves nothing about the production store.
-
-- **PostgreSQL:** `select catcode from pg_get_keywords() where word = '<lower-case name>'`
-  — `reserved` cannot be used as an identifier at all. `END` is reserved;
-  `START`, `LANGUAGE`, `TEXT`, `TYPE` and `NAME` are unreserved and fine.
-- **HSQLDB** (the usual test store): default settings accept SQL-standard
-  keywords as identifiers, so it will NOT warn you — `START`, `END` and
-  `LANGUAGE` all pass there in DDL, INSERT, SELECT and UPDATE.
-
-Rename the field or give it an explicit prefixed `@Column(name = "...")`. Common
-offenders an entity field naturally produces: `end`, `order`, `user`, `group`,
-`desc`, `references`.
-
-This is the expensive failure mode. Liquibase emits the `createTable` unquoted
-and EclipseLink emits `t.END` unquoted, so the defect surfaces only when the
-changelog is first applied to the production dialect — after compile, static
-analysis and a full green `clean test` have all passed.
 
 ## Entity Template
 
@@ -82,6 +58,24 @@ public class Customer {
     // getters and setters
 }
 ```
+
+## Column names
+
+A column name derived from the field name may be an SQL **reserved word**, and
+the dialects a project targets do not agree about which words those are. The
+check is per dialect, not per SQL standard: a green suite against the test store
+proves nothing about the production store.
+
+- **PostgreSQL:** `select catcode from pg_get_keywords() where word = '<lower-case name>'`
+  — `reserved` cannot be used as an identifier at all. `END` is reserved;
+  `START`, `LANGUAGE`, `TEXT`, `TYPE` and `NAME` are unreserved and fine.
+- **HSQLDB** (the usual test store): default settings accept SQL-standard
+  keywords as identifiers, so it will NOT warn you — `START`, `END` and
+  `LANGUAGE` all pass there in DDL, INSERT, SELECT and UPDATE.
+
+Rename the field or give it an explicit prefixed `@Column(name = "...")`. Common
+offenders an entity field naturally produces: `end`, `order`, `user`, `group`,
+`desc`, `references`.
 
 ## Id strategy — an explicit choice, not a default
 

--- a/content/skills/jmix-create-liquibase-changelog/SKILL.md
+++ b/content/skills/jmix-create-liquibase-changelog/SKILL.md
@@ -42,6 +42,15 @@ Jmix add-on that owns database tables.
 | FileRef | `varchar(1024)` |
 | Enum id string | `varchar(50)` |
 
+A column NAME is not a free choice either: if it is a reserved word in any
+targeted dialect the `createTable` fails there, and the dialects disagree —
+PostgreSQL rejects `END` outright (check with
+`select catcode from pg_get_keywords() where word = '<lower-case name>'`) while
+HSQLDB accepts SQL-standard keywords as identifiers by default and never warns.
+Liquibase emits the name unquoted, so this surfaces only when the changelog
+first reaches the production dialect. Rename instead of quoting. See
+`jmix-create-entity` (Column names).
+
 An entity with an **assigned natural key** takes the id column type of its Java
 field — `bigint` for a `Long` id, not `${uuid.type}`. See `jmix-create-entity`
 (Id strategy).


### PR DESCRIPTION
Fixes #120.

Drafted from a field report while the problem was fresh, by the agent that hit it. It is unreviewed: treat the wording as a starting point, not a proposal to merge as-is.

## Change

- `jmix-create-entity`: a pointer on step 6 plus a new short section giving the per-dialect check — the PostgreSQL `pg_get_keywords()` query, the note that HSQLDB accepts SQL-standard keywords by default and will not warn, and the common offenders (`end`, `order`, `user`, `group`, `desc`, `references`).
- `jmix-create-liquibase-changelog`: one paragraph in Standard Types saying the column NAME is not a free choice either, cross-referencing the entity skill.