### PR TITLE
jmix-create-entity: state the write side of soft-delete filtering

### DIFF
--- a/content/skills/jmix-create-entity/SKILL.md
+++ b/content/skills/jmix-create-entity/SKILL.md
@@ -303,6 +303,21 @@ private Parent parent;
 
 Add audit fields with the Spring Data annotations from `org.springframework.data.annotation`: `@CreatedBy`, `@CreatedDate`, `@LastModifiedBy`, `@LastModifiedDate`. For soft delete add `@DeletedBy` and `@DeletedDate` from `io.jmix.core.annotation` — soft-deleted rows are then auto-filtered out of `DataManager`/JPQL queries.
 
+That filter is installed on the EclipseLink descriptor, so it applies to **writes** as well as to the queries the application issues. EclipseLink's own relationship read during flush is filtered too, so **inserting or updating a row whose reference points at a soft-deleted entity fails** — with a message that names the wrong cause:
+
+```
+IllegalStateException: During synchronization a new object was found through
+a relationship that was not marked cascade PERSIST
+```
+
+Nothing in that text points at soft deletion, and no `cascade` setting fixes it. If a reference to a soft-deleted row is a legal state in the model (a child that may sit beneath a deleted parent), the save must carry the hint:
+
+```java
+dataManager.save(new SaveContext()
+        .setHint(PersistenceHints.SOFT_DELETION, false)
+        .saving(entity));
+```
+
 ## Calculated and Transient Properties
 
 Non-persistent derived attributes use `@JmixProperty` + `@Transient` + `@DependsOnProperties({"a", "b"})` (`@JmixProperty` from `io.jmix.core.metamodel.annotation`). The same applies to an `@InstanceName` method: it must carry `@DependsOnProperties` listing every attribute it reads so they are fetched.

--- a/content/skills/jmix-create-entity/SKILL.md
+++ b/content/skills/jmix-create-entity/SKILL.md
@@ -303,14 +303,15 @@ private Parent parent;
 
 Add audit fields with the Spring Data annotations from `org.springframework.data.annotation`: `@CreatedBy`, `@CreatedDate`, `@LastModifiedBy`, `@LastModifiedDate`. For soft delete add `@DeletedBy` and `@DeletedDate` from `io.jmix.core.annotation` — soft-deleted rows are then auto-filtered out of `DataManager`/JPQL queries.
 
-That filter is installed on the EclipseLink descriptor, so it applies to **writes** as well as to the queries the application issues. EclipseLink's own relationship read during flush is filtered too, so **inserting or updating a row whose reference points at a soft-deleted entity fails** — with a message that names the wrong cause:
+That filter applies to **writes** as well as to the queries the application issues. 
+Inserting or updating a row whose reference points at a soft-deleted entity fails — with a message that names the wrong cause:
 
 ```
 IllegalStateException: During synchronization a new object was found through
 a relationship that was not marked cascade PERSIST
 ```
 
-Nothing in that text points at soft deletion, and no `cascade` setting fixes it. If a reference to a soft-deleted row is a legal state in the model (a child that may sit beneath a deleted parent), the save must carry the hint:
+If a reference to a soft-deleted row is a legal state in the model (a child that may sit beneath a deleted parent), the save must carry the hint:
 
 ```java
 dataManager.save(new SaveContext()


### PR DESCRIPTION
Fixes #121.

Drafted from a field report while the problem was fresh, by the agent that hit it. It is unreviewed: treat the wording as a starting point, not a proposal to merge as-is.

## Change

Extends "Auditing and Soft Delete" with the write consequence: the filter sits on the EclipseLink descriptor, so inserting or updating a row whose reference points at a soft-deleted entity fails with the misleading `not marked cascade PERSIST` error. Quotes that message so a search finds this section, and gives the `SaveContext` form that carries `PersistenceHints.SOFT_DELETION = false`.