### PR TITLE
jmix-create-enum: state that extra constant state is invisible to the metamodel

### DIFF
--- a/content/skills/jmix-create-enum/SKILL.md
+++ b/content/skills/jmix-create-enum/SKILL.md
@@ -55,6 +55,14 @@ public enum TransactionType implements EnumClass<String> {
 }
 ```
 
+A constant may carry further constructor arguments and accessors beside the stable id — a
+policy value a validator reads, a display order, a threshold. They are invisible to the
+metamodel: an enum is not a `@JmixEntity`, so the attribute loader never runs over it, and
+the enumeration datatype Jmix builds for an `EnumClass` reads only `getEnumConstants()` and
+`getId()`. So extra state needs no message key and appears in no fetch plan. Only the
+**stable id** is ever persisted — never a second field, however convenient its value looks
+as a column.
+
 ## Entity Mapping
 
 ```java


### PR DESCRIPTION
Fixes #130.

Drafted from a field report while the problem was fresh, by the agent that hit it. It is unreviewed: treat the wording as a starting point, not a proposal to merge as-is.

## Change

Adds a note under the Enum Template saying that an `EnumClass` constant may carry constructor arguments and accessors beyond the stable id, that they are invisible to the metamodel (an enum is not a `@JmixEntity`; the enumeration datatype reads only `getEnumConstants()` and `getId()`) and therefore owe no message key, and that only the stable id is ever persisted.